### PR TITLE
stop ignoring firebase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # config
-/src/utils
+#/src/utils
 
 # production
 /build

--- a/src/utils/firebaseConfig.js
+++ b/src/utils/firebaseConfig.js
@@ -1,0 +1,15 @@
+import firebase from 'firebase';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBUi1WODzR5pe1szgwT3r8Q7qWiPa9eKcg",
+  authDomain: "katatak-374aa.firebaseapp.com",
+  databaseURL: "https://katatak-374aa-default-rtdb.firebaseio.com",
+  projectId: "katatak-374aa",
+  storageBucket: "katatak-374aa.appspot.com",
+  messagingSenderId: "804376054896",
+  appId: "1:804376054896:web:0581e6e340ca1f4ad338b5"
+};
+// Initialize Firebase
+firebase.initializeApp(firebaseConfig);
+
+export default firebase;


### PR DESCRIPTION
It is safe to expose firebase config in the github files, as it is safe to expose them in the client.

We still can improve a lot (see https://firebase.google.com/docs/projects/api-keys), but this should fix the ci build